### PR TITLE
Add comprehensive documentation in Japanese and English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
-# slack-explorer-mcp
+# Slack Explorer MCP Server
+
+A Model Context Protocol (MCP) server specialized in **retrieving information** from Slack messages and threads. It provides tools to access messages that the authenticated user can view using a User Token (xoxp).
+
+## Available Tools
+
+- Message Search (`search_messages`)
+  - Search Slack messages with advanced filtering options. You can search by channel, user, date range, and specific features (reactions, files, etc.).
+  - Parameters
+    - `query`: Basic search query (without modifiers)
+    - `in_channel`: Filter by channel name (e.g., "general", "team-dev")
+    - `from_user`: Search messages from specific user (User ID)
+    - `with`: Search DMs/threads with specific users (array of User IDs)
+    - `before`, `after`, `on`: Date range filtering (YYYY-MM-DD format)
+    - `during`: Period specification (e.g., "July", "2023")
+    - `has`: Messages containing specific features (emoji, "pin", "file", "link", "reaction")
+    - `hasmy`: Messages where you reacted with specific emoji
+    - `sort`: Sort method ("score" or "timestamp")
+    - `count`: Number of results per page (1-100, default: 20)
+    - `page`: Page number (1-100, default: 1)
+
+- Thread Replies (`get_thread_replies`)
+  - Get all replies in a message thread. Supports pagination for efficiently handling large numbers of replies.
+  - Parameters
+    - `channel_id`: Channel ID (required)
+    - `thread_ts`: Parent message timestamp (required)
+    - `limit`: Number of replies to retrieve (1-1000, default: 100)
+    - `cursor`: Pagination cursor
+
+## Setup
+
+### Getting a Slack User Token
+
+1. Create an app at [Slack API](https://api.slack.com/apps)
+2. Add the following User Token Scopes in OAuth & Permissions:
+   - `search:read` - For message search
+   - `channels:read`, `channels:history` - For public channels
+   - `groups:read`, `groups:history` - For private channels
+   - `im:read`, `im:history` - For direct messages
+   - `mpim:read`, `mpim:history` - For group direct messages
+   - `users:read` - For user information
+3. Install the app to your workspace
+4. Get the User OAuth Token (starts with xoxp-)
+
+### MCP Server Configuration
+
+1. Configure mcp.json
+
+    ```json
+    {
+      "mcpServers": {
+        "slack-explorer-mcp": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm",
+            "-e", "SLACK_USER_TOKEN=xoxp-your-token-here",
+            "ghcr.io/shibayu36/slack-explorer-mcp:latest"
+          ]
+        }
+      }
+    }
+    ```
+
+    If you're using Claude Code:
+
+    ```bash
+    claude mcp add slack-explorer-mcp -- docker run -i --rm \
+      -e SLACK_USER_TOKEN=xoxp-your-token-here \
+      ghcr.io/shibayu36/slack-explorer-mcp:latest
+    ```
+
+2. Use the agent to perform Slack searches
+
+    Examples:
+    - "Search for meeting-related messages in the general channel from last week"
+    - "Find messages from @john.doe about 'project'"
+    - "Get all thread replies for this post"
+
+## Usage
+
+### Common Search Patterns
+
+- **Search in a specific channel**
+  ```
+  Search for "release" messages in the general channel
+  ```
+
+- **Search messages from a specific user**
+  ```
+  Search for yesterday's messages from @john.doe
+  ```
+
+- **Search messages with reactions**
+  ```
+  Search for messages with :fire: reactions
+  ```
+
+- **Search messages you reacted to**
+  ```
+  Search for messages where you reacted with :eyes:
+  ```
+
+- **Search messages with file attachments**
+  ```
+  Search for messages with file attachments
+  ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,105 @@
+# Slack Explorer MCP Server
+
+Slackのメッセージやスレッドなどの**情報の取得**に特化したModel Context Protocol (MCP) サーバーです。User Token（xoxp）を使用して、認可したユーザーがアクセス可能なメッセージを取得するツールを提供します。
+
+## 提供するツール
+
+- メッセージ検索 (`search_messages`)
+  - 高度な検索フィルタ付きでSlackメッセージを検索します。チャンネル指定、ユーザー指定、日付範囲、特定の機能（リアクション、ファイル等）を含むメッセージの検索が可能です。
+  - パラメータ
+    - `query`: 基本検索クエリ（修飾子なし）
+    - `in_channel`: チャンネル名での絞り込み（例: "general", "チーム-dev"）
+    - `from_user`: 特定ユーザーのメッセージを検索（ユーザーID）
+    - `with`: 特定ユーザーとのDM/スレッドを検索（ユーザーID配列）
+    - `before`, `after`, `on`: 日付範囲指定（YYYY-MM-DD形式）
+    - `during`: 期間指定（例: "July", "2023"）
+    - `has`: 特定機能を含むメッセージ（絵文字、"pin", "file", "link", "reaction"）
+    - `hasmy`: 自分がリアクションした絵文字を含むメッセージ
+    - `sort`: ソート方法（"score" or "timestamp"）
+    - `count`: ページあたりの結果数（1-100、デフォルト: 20）
+    - `page`: ページ番号（1-100、デフォルト: 1）
+
+- スレッド返信取得 (`get_thread_replies`)
+  - 特定メッセージのスレッド返信一覧を取得します。ページネーション対応で大量の返信も効率的に取得できます。
+  - パラメータ
+    - `channel_id`: チャンネルID（必須）
+    - `thread_ts`: 親メッセージのタイムスタンプ（必須）
+    - `limit`: 取得する返信数（1-1000、デフォルト: 100）
+    - `cursor`: ページネーション用カーソル
+
+## セットアップ
+
+### Slack User Tokenの取得
+
+1. [Slack API](https://api.slack.com/apps)でアプリを作成
+2. OAuth & Permissionsで以下のUser Token Scopesを追加：
+   - `search:read` - メッセージ検索用
+   - `channels:read`, `channels:history` - 公開チャンネル用
+   - `groups:read`, `groups:history` - 非公開チャンネル用
+   - `im:read`, `im:history` - DM用
+   - `mpim:read`, `mpim:history` - グループDM用
+   - `users:read` - ユーザー情報取得用
+3. ワークスペースにアプリをインストール
+4. User OAuth Token（xoxp-で始まるトークン）を取得
+
+### MCPサーバーの設定
+
+1. mcp.jsonを設定
+
+    ```json
+    {
+      "mcpServers": {
+        "slack-explorer-mcp": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm",
+            "-e", "SLACK_USER_TOKEN=xoxp-your-token-here",
+            "ghcr.io/shibayu36/slack-explorer-mcp:latest"
+          ]
+        }
+      }
+    }
+    ```
+
+    Claude Codeを使用している場合:
+
+    ```bash
+    claude mcp add slack-explorer-mcp -- docker run -i --rm \
+      -e SLACK_USER_TOKEN=xoxp-your-token-here \
+      ghcr.io/shibayu36/slack-explorer-mcp:latest
+    ```
+
+2. エージェントを利用してSlack検索を実行
+
+    例:
+    - 「generalチャンネルで先週の会議関連のメッセージを検索して」
+    - 「@john.doeさんのメッセージで"プロジェクト"に関するものを探して」
+    - 「この投稿のスレッド返信を全部取得して」
+
+## 使い方
+
+### よくある検索パターン
+
+- **特定チャンネルでの検索**
+  ```
+  generalチャンネルで"リリース"に関するメッセージを検索
+  ```
+
+- **特定ユーザーのメッセージ検索**
+  ```
+  @john.doeさんの昨日のメッセージを検索
+  ```
+
+- **リアクション付きメッセージの検索**
+  ```
+  :fire:のリアクションがついているメッセージを検索
+  ```
+
+- **自分がリアクションしたメッセージ**
+  ```
+  自分が:eyes:のリアクションをつけたメッセージを検索
+  ```
+
+- **ファイル付きメッセージの検索**
+  ```
+  ファイルが添付されているメッセージを検索
+  ```


### PR DESCRIPTION
## Summary
• Added comprehensive Japanese README (README_ja.md) with detailed MCP tools documentation and setup instructions
• Added comprehensive English README (README.md) with tool documentation and setup guide
• Both documents provide complete guidance for users to understand and use the Slack Explorer MCP server