### PR TITLE
Implement get_user_profiles MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ A Model Context Protocol (MCP) server specialized in **retrieving information** 
     - `limit`: Number of replies to retrieve (1-1000, default: 100)
     - `cursor`: Pagination cursor
 
+- User Profiles (`get_user_profiles`)
+  - Get profile information for multiple users in bulk. Retrieve display names, real names, email addresses, and other profile information by specifying a list of user IDs.
+  - Parameters
+    - `user_ids`: Array of user IDs (required, max 100)
+
 ## Setup
 
 ### Getting a Slack User Token
@@ -38,7 +43,7 @@ A Model Context Protocol (MCP) server specialized in **retrieving information** 
    - `groups:read`, `groups:history` - For private channels
    - `im:read`, `im:history` - For direct messages
    - `mpim:read`, `mpim:history` - For group direct messages
-   - `users:read` - For user information
+   - `users:read`, `users.profile:read` - For user information and profiles
 3. Install the app to your workspace
 4. Get the User OAuth Token (starts with xoxp-)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -27,6 +27,11 @@ Slackのメッセージやスレッドなどの**情報の取得**に特化し�
     - `limit`: 取得する返信数（1-1000、デフォルト: 100）
     - `cursor`: ページネーション用カーソル
 
+- ユーザープロフィール一括取得 (`get_user_profiles`)
+  - 複数のユーザーのプロフィール情報を一括で取得します。ユーザーIDのリストを指定して、表示名、実名、メールアドレスなどの情報を取得できます。
+  - パラメータ
+    - `user_ids`: ユーザーID配列（必須、最大100個）
+
 ## セットアップ
 
 ### Slack User Tokenの取得
@@ -38,7 +43,7 @@ Slackのメッセージやスレッドなどの**情報の取得**に特化し�
    - `groups:read`, `groups:history` - 非公開チャンネル用
    - `im:read`, `im:history` - DM用
    - `mpim:read`, `mpim:history` - グループDM用
-   - `users:read` - ユーザー情報取得用
+   - `users:read`, `users.profile:read` - ユーザー情報・プロフィール取得用
 3. ワークスペースにアプリをインストール
 4. User OAuth Token（xoxp-で始まるトークン）を取得
 

--- a/docs/onetime/20250823-requirements-ja.md
+++ b/docs/onetime/20250823-requirements-ja.md
@@ -44,11 +44,14 @@
   - 高度な検索フィルタ（with, has, hasmy）対応
   - ページネーション完全対応
   - エラーハンドリング実装済み
+- **`get_thread_replies`** — Get all replies in a message thread
+  - ページネーション対応
+  - エラーハンドリング実装済み
 
 ### 未実装（🚧）
 - `list_channels` — List channels in the workspace with pagination
 - `get_channel_history` — Get recent messages from a channel
-- `get_thread_replies` — Get all replies in a message thread
+- `get_user_profiles` — Get multiple users profile information in bulk
 
 ### search_messages スキーマ詳細
 
@@ -156,6 +159,39 @@
 - User Token（xoxp）を使用し、`conversations.replies` APIを呼び出す
 - ページネーションは`cursor`と`limit`で制御
 - `has_more`がtrueの場合、`response_metadata.next_cursor`を次回リクエストの`cursor`に使用
+
+### get_user_profiles スキーマ詳細
+
+#### 入力パラメータ
+```json
+{
+  "user_ids": "array (required)"         // ユーザーID配列（例: ["U1234567", "U2345678"]）最大100個
+}
+```
+
+#### 出力形式
+```json
+[
+  {
+    "user_id": "U1234567",
+    "display_name": "John Doe",
+    "real_name": "John Doe",
+    "email": "john@example.com"
+  },
+  {
+    "user_id": "U2345678",
+    "error": "user_not_found"              // エラーの場合はerrorフィールドのみ
+  }
+]
+```
+
+#### 実装上の注意点
+- `user_ids`は必須パラメータで、最大100個のユーザーIDを受け取る
+- 各ユーザーIDは`U`で始まる形式（例: `U1234567`）である必要がある
+- Slack APIの`users.profile.get`を順次呼び出し、個別のエラーも含めて結果を返す
+- User Token（xoxp）を使用し、`users.profile.get` APIを呼び出す
+- 一部のユーザーでエラーが発生しても、他のユーザーの情報は正常に返す
+- 必要スコープ: `users:read`, `users.profile:read`
 
 ※ 他のツールの入力・出力詳細は後続実装時に定義
 

--- a/docs/onetime/20250823-requirements-ja.md
+++ b/docs/onetime/20250823-requirements-ja.md
@@ -47,11 +47,13 @@
 - **`get_thread_replies`** — Get all replies in a message thread
   - ページネーション対応
   - エラーハンドリング実装済み
+- **`get_user_profiles`** — Get multiple users profile information in bulk
+  - バリデーション実装済み（最大100個、UserID形式チェック）
+  - 個別エラーハンドリング実装済み
 
 ### 未実装（🚧）
 - `list_channels` — List channels in the workspace with pagination
 - `get_channel_history` — Get recent messages from a channel
-- `get_user_profiles` — Get multiple users profile information in bulk
 
 ### search_messages スキーマ詳細
 
@@ -199,13 +201,13 @@
 
 ## Slack API依存とスコープ
 - **使用SDK**: `github.com/slack-go/slack` - 導入済み ✅
-- 使用メソッド（想定）：`conversations.list`, `conversations.history`, `conversations.replies`, `users.list`（表示名解決用）, `search.messages`（検索）
-  - **実装済み**: `search.messages` ✅
+- 使用メソッド（想定）：`conversations.list`, `conversations.history`, `conversations.replies`, `users.list`（表示名解決用）, `search.messages`（検索）, `users.profile.get`（プロフィール取得）
+  - **実装済み**: `search.messages`, `conversations.replies`, `users.profile.get` ✅
 - 必要スコープ（User Token想定）
   - 公開：`channels:read`, `channels:history`
   - 非公開：`groups:read`, `groups:history`
   - DM/マルチDM：`im:read`, `im:history`, `mpim:read`, `mpim:history`
-  - ユーザー：`users:read`
+  - ユーザー：`users:read`, `users.profile:read`
   - 検索：`search:read` ✅
 - 注意点
   - プライベート/DMは**ユーザー参加済み**でなければ取得不可
@@ -246,11 +248,18 @@
    - パラメータバリデーション実装
    - Slackエラーマッピング実装
    - ページネーション対応
+2) **`get_thread_replies`** - 完全実装済み
+   - パラメータバリデーション実装
+   - ページネーション対応
+   - エラーハンドリング実装
+3) **`get_user_profiles`** - 完全実装済み
+   - バリデーション実装（最大100個、UserID形式チェック）
+   - 個別エラーハンドリング実装
+   - フラット配列レスポンス形式
 
 ### 未実装（🚧）
-2) `get_thread_replies` - 未実装
-3) `get_channel_history` - 未実装  
-4) `list_channels` - 未実装
+4) `get_channel_history` - 未実装  
+5) `list_channels` - 未実装
 
 ### 技術的進展
 - **認証・エラーハンドリング**: 完了済み

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/handler.go
+++ b/handler.go
@@ -402,8 +402,51 @@ type UserProfile struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// GetUserProfiles handles the get_user_profiles tool call
 func (h *Handler) GetUserProfiles(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	// TODO: implement get_user_profiles
-	return mcp.NewToolResultError("get_user_profiles not implemented yet"), nil
+	userIDs := request.GetStringSlice("user_ids", []string{})
+
+	if len(userIDs) == 0 {
+		return mcp.NewToolResultError("user_ids is required and cannot be empty"), nil
+	}
+	if len(userIDs) > 100 {
+		return mcp.NewToolResultError("user_ids cannot exceed 100 entries"), nil
+	}
+
+	var profiles []UserProfile
+
+	for _, userID := range userIDs {
+		profile := h.getUserProfile(userID)
+		profiles = append(profiles, profile)
+	}
+
+	jsonData, err := json.Marshal(profiles)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal response: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(jsonData)), nil
+}
+
+func (h *Handler) getUserProfile(userID string) UserProfile {
+	if !strings.HasPrefix(userID, "U") {
+		return UserProfile{
+			UserID: userID,
+			Error:  "invalid user ID format. Must start with 'U' (e.g., 'U1234567')",
+		}
+	}
+
+	slackProfile, err := h.slackClient.GetUserProfile(userID)
+	if err != nil {
+		return UserProfile{
+			UserID: userID,
+			Error:  err.Error(),
+		}
+	}
+
+	return UserProfile{
+		UserID:      userID,
+		DisplayName: slackProfile.DisplayName,
+		RealName:    slackProfile.RealName,
+		Email:       slackProfile.Email,
+	}
 }

--- a/handler.go
+++ b/handler.go
@@ -392,3 +392,18 @@ func (h *Handler) convertToThreadResponse(messages []slack.Message, hasMore bool
 
 	return response
 }
+
+// UserProfile represents a user profile result
+type UserProfile struct {
+	UserID      string `json:"user_id"`
+	DisplayName string `json:"display_name,omitempty"`
+	RealName    string `json:"real_name,omitempty"`
+	Email       string `json:"email,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// GetUserProfiles handles the get_user_profiles tool call
+func (h *Handler) GetUserProfiles(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// TODO: implement get_user_profiles
+	return mcp.NewToolResultError("get_user_profiles not implemented yet"), nil
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 )
@@ -372,5 +375,97 @@ func TestHandler_buildThreadRepliesParams(t *testing.T) {
 				assert.Equal(t, tc.expectErr, err.Error())
 			})
 		}
+	})
+}
+
+func TestHandler_GetUserProfiles(t *testing.T) {
+	t.Run("can retrieve profiles for multiple users", func(t *testing.T) {
+		mockClient := &SlackClientMock{}
+		mockClient.On("GetUserProfile", "U1234567").Return(&slack.UserProfile{
+			DisplayName: "john",
+			RealName:    "John Doe",
+			Email:       "john@example.com",
+		}, nil)
+		mockClient.On("GetUserProfile", "U2345678").Return(&slack.UserProfile{
+			DisplayName: "jane",
+			RealName:    "Jane Doe",
+			Email:       "jane@example.com",
+		}, nil)
+
+		handler := &Handler{
+			slackClient: mockClient,
+		}
+
+		req := mcp.CallToolRequest{
+			Params: struct {
+				Name      string    `json:"name"`
+				Arguments any       `json:"arguments,omitempty"`
+				Meta      *mcp.Meta `json:"_meta,omitempty"`
+			}{
+				Name: "get_user_profiles",
+				Arguments: map[string]interface{}{
+					"user_ids": []string{"U1234567", "U2345678"},
+				},
+			},
+		}
+		res, err := handler.GetUserProfiles(t.Context(), req)
+		assert.NoError(t, err)
+
+		var profiles []map[string]interface{}
+		err = json.Unmarshal([]byte(res.Content[0].(mcp.TextContent).Text), &profiles)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(profiles))
+
+		assert.Equal(t, "U1234567", profiles[0]["user_id"])
+		assert.Equal(t, "john", profiles[0]["display_name"])
+		assert.Equal(t, "John Doe", profiles[0]["real_name"])
+		assert.Equal(t, "john@example.com", profiles[0]["email"])
+
+		assert.Equal(t, "U2345678", profiles[1]["user_id"])
+		assert.Equal(t, "jane", profiles[1]["display_name"])
+		assert.Equal(t, "Jane Doe", profiles[1]["real_name"])
+		assert.Equal(t, "jane@example.com", profiles[1]["email"])
+	})
+
+	t.Run("can retrieve other user profiles even if one user fails", func(t *testing.T) {
+		mockClient := &SlackClientMock{}
+		mockClient.On("GetUserProfile", "U1234567").Return(&slack.UserProfile{
+			DisplayName: "john",
+			RealName:    "John Doe",
+			Email:       "john@example.com",
+		}, nil)
+		mockClient.On("GetUserProfile", "U2345678").Return(nil, errors.New("user not found"))
+
+		handler := &Handler{
+			slackClient: mockClient,
+		}
+
+		req := mcp.CallToolRequest{
+			Params: struct {
+				Name      string    `json:"name"`
+				Arguments any       `json:"arguments,omitempty"`
+				Meta      *mcp.Meta `json:"_meta,omitempty"`
+			}{
+				Name: "get_user_profiles",
+				Arguments: map[string]interface{}{
+					"user_ids": []string{"U1234567", "U2345678"},
+				},
+			},
+		}
+		res, err := handler.GetUserProfiles(t.Context(), req)
+		assert.NoError(t, err)
+
+		var profiles []map[string]interface{}
+		err = json.Unmarshal([]byte(res.Content[0].(mcp.TextContent).Text), &profiles)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(profiles))
+
+		assert.Equal(t, "U1234567", profiles[0]["user_id"])
+		assert.Equal(t, "john", profiles[0]["display_name"])
+		assert.Equal(t, "John Doe", profiles[0]["real_name"])
+		assert.Equal(t, "john@example.com", profiles[0]["email"])
+
+		assert.Equal(t, "U2345678", profiles[1]["user_id"])
+		assert.Equal(t, "user not found", profiles[1]["error"])
 	})
 }

--- a/main.go
+++ b/main.go
@@ -109,6 +109,23 @@ func main() {
 		handler.GetThreadReplies,
 	)
 
+	// Add get_user_profiles tool
+	s.AddTool(
+		mcp.NewTool("get_user_profiles",
+			mcp.WithDescription("Get multiple users profile information in bulk"),
+			mcp.WithArray("user_ids",
+				mcp.Required(),
+				mcp.Items(
+					map[string]interface{}{
+						"type": "string",
+					},
+				),
+				mcp.Description("Array of user IDs to retrieve profiles for (e.g., ['U1234567', 'U2345678']). Maximum 100 user IDs."),
+			),
+		),
+		handler.GetUserProfiles,
+	)
+
 	if err := server.ServeStdio(s); err != nil {
 		fmt.Printf("Server error: %v\n", err)
 		log.Fatalf("Failed to serve: %v", err)

--- a/slack_client.go
+++ b/slack_client.go
@@ -10,6 +10,7 @@ import (
 type SlackClient interface {
 	SearchMessages(query string, params slack.SearchParameters) (*slack.SearchMessages, error)
 	GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
+	GetUserProfile(userID string) (*slack.UserProfile, error)
 }
 
 type slackClient struct {
@@ -39,6 +40,17 @@ func (c *slackClient) GetConversationReplies(params *slack.GetConversationReplie
 		return nil, false, "", c.mapError(err)
 	}
 	return messages, hasMore, nextCursor, nil
+}
+
+// GetUserProfile retrieves a user's profile information
+func (c *slackClient) GetUserProfile(userID string) (*slack.UserProfile, error) {
+	profile, err := c.client.GetUserProfile(&slack.GetUserProfileParameters{
+		UserID: userID,
+	})
+	if err != nil {
+		return nil, c.mapError(err)
+	}
+	return profile, nil
 }
 
 func (c *slackClient) mapError(err error) error {

--- a/slack_client_mock_test.go
+++ b/slack_client_mock_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/mock"
+)
+
+type SlackClientMock struct{ mock.Mock }
+
+func (m *SlackClientMock) SearchMessages(query string, params slack.SearchParameters) (*slack.SearchMessages, error) {
+	args := m.Called(query, params)
+	var res *slack.SearchMessages
+	if v := args.Get(0); v != nil {
+		res = v.(*slack.SearchMessages)
+	}
+	return res, args.Error(1)
+}
+
+func (m *SlackClientMock) GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error) {
+	args := m.Called(params)
+	msgs, _ := args.Get(0).([]slack.Message)
+	return msgs, args.Bool(1), args.String(2), args.Error(3)
+}
+
+func (m *SlackClientMock) GetUserProfile(userID string) (*slack.UserProfile, error) {
+	args := m.Called(userID)
+	var res *slack.UserProfile
+	if v := args.Get(0); v != nil {
+		res = v.(*slack.UserProfile)
+	}
+	return res, args.Error(1)
+}


### PR DESCRIPTION
## Summary
Implements the `get_user_profiles` MCP tool to retrieve multiple user profile information in bulk.

- Add new MCP tool definition and handler
- Implement SlackClient interface extension with GetUserProfile method  
- Add comprehensive validation and error handling
- Update documentation and required OAuth scopes
- Add unit tests with mock support