### PR TITLE
feat: Add debug logging with slog

### DIFF
--- a/.claude/tmp/test_debug_log.sh
+++ b/.claude/tmp/test_debug_log.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Test debug logging
+
+echo "=== Testing with LOG_LEVEL=DEBUG ==="
+LOG_LEVEL=DEBUG ./slack-explorer-mcp 2>&1 | head -20
+
+echo ""
+echo "=== Testing with LOG_LEVEL=INFO (default) ==="
+LOG_LEVEL=INFO ./slack-explorer-mcp 2>&1 | head -20
+
+echo ""
+echo "=== Testing without LOG_LEVEL (default should be INFO) ==="
+./slack-explorer-mcp 2>&1 | head -20

--- a/main.go
+++ b/main.go
@@ -162,22 +162,27 @@ func main() {
 	}
 }
 
-// setupLogging configures slog based on LOG_LEVEL environment variable
+// setupLogging configures slog based on DEBUG or LOG_LEVEL environment variable
 func setupLogging() {
-	logLevel := strings.ToUpper(os.Getenv("LOG_LEVEL"))
-	var level slog.Level
+	var level slog.Level = slog.LevelInfo // Default to INFO level
 
-	switch logLevel {
-	case "DEBUG":
+	// Check DEBUG=1 first
+	if os.Getenv("DEBUG") == "1" {
 		level = slog.LevelDebug
-	case "INFO":
-		level = slog.LevelInfo
-	case "WARN":
-		level = slog.LevelWarn
-	case "ERROR":
-		level = slog.LevelError
-	default:
-		level = slog.LevelInfo // Default to INFO level
+	}
+
+	// LOG_LEVEL takes precedence if set
+	if logLevel := strings.ToUpper(os.Getenv("LOG_LEVEL")); logLevel != "" {
+		switch logLevel {
+		case "DEBUG":
+			level = slog.LevelDebug
+		case "INFO":
+			level = slog.LevelInfo
+		case "WARN":
+			level = slog.LevelWarn
+		case "ERROR":
+			level = slog.LevelError
+		}
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{

--- a/main.go
+++ b/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"log/slog"
+	"os"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -11,6 +14,9 @@ import (
 const Version = "0.3.0"
 
 func main() {
+	// Set up logging based on LOG_LEVEL environment variable
+	setupLogging()
+
 	// Initialize handler
 	handler := NewHandler()
 
@@ -154,4 +160,28 @@ func main() {
 		fmt.Printf("Server error: %v\n", err)
 		log.Fatalf("Failed to serve: %v", err)
 	}
+}
+
+// setupLogging configures slog based on LOG_LEVEL environment variable
+func setupLogging() {
+	logLevel := strings.ToUpper(os.Getenv("LOG_LEVEL"))
+	var level slog.Level
+
+	switch logLevel {
+	case "DEBUG":
+		level = slog.LevelDebug
+	case "INFO":
+		level = slog.LevelInfo
+	case "WARN":
+		level = slog.LevelWarn
+	case "ERROR":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo // Default to INFO level
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: level,
+	}))
+	slog.SetDefault(logger)
 }

--- a/slack_client.go
+++ b/slack_client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/slack-go/slack"
 )
@@ -28,40 +29,76 @@ func NewSlackClient(userToken string) SlackClient {
 
 // SearchMessages searches for messages in Slack workspace
 func (c *slackClient) SearchMessages(query string, params slack.SearchParameters) (*slack.SearchMessages, error) {
+	slog.Debug("Calling Slack API: SearchMessages",
+		"query", query,
+		"params", params,
+	)
 	messages, err := c.client.SearchMessages(query, params)
 	if err != nil {
+		slog.Debug("SearchMessages failed", "error", err)
 		return nil, c.mapError(err)
 	}
+	slog.Debug("SearchMessages completed",
+		"total_count", messages.Total,
+	)
 	return messages, nil
 }
 
 // GetConversationReplies retrieves replies to a message thread
 func (c *slackClient) GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error) {
+	slog.Debug("Calling Slack API: GetConversationReplies",
+		"channel_id", params.ChannelID,
+		"thread_ts", params.Timestamp,
+		"limit", params.Limit,
+		"cursor", params.Cursor,
+	)
 	messages, hasMore, nextCursor, err := c.client.GetConversationReplies(params)
 	if err != nil {
+		slog.Debug("GetConversationReplies failed", "error", err)
 		return nil, false, "", c.mapError(err)
 	}
+	slog.Debug("GetConversationReplies completed",
+		"messages_count", len(messages),
+		"has_more", hasMore,
+		"next_cursor", nextCursor,
+	)
 	return messages, hasMore, nextCursor, nil
 }
 
 // GetUserProfile retrieves a user's profile information
 func (c *slackClient) GetUserProfile(userID string) (*slack.UserProfile, error) {
+	slog.Debug("Calling Slack API: GetUserProfile",
+		"user_id", userID,
+	)
 	profile, err := c.client.GetUserProfile(&slack.GetUserProfileParameters{
 		UserID: userID,
 	})
 	if err != nil {
+		slog.Debug("GetUserProfile failed", "error", err)
 		return nil, c.mapError(err)
 	}
+	slog.Debug("GetUserProfile completed",
+		"user_id", userID,
+		"display_name", profile.DisplayName,
+		"real_name", profile.RealName,
+	)
 	return profile, nil
 }
 
 // GetUsers retrieves users from the workspace
 // The slack-go library handles pagination internally when using GetUsersContext
 func (c *slackClient) GetUsers(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error) {
+	slog.Debug("Calling Slack API: GetUsers",
+		"options_count", len(options),
+	)
 	users, err := c.client.GetUsersContext(ctx, options...)
 	if err != nil {
+		slog.Debug("GetUsers failed", "error", err)
 		return nil, c.mapError(err)
 	}
+	slog.Debug("GetUsers completed",
+		"users_count", len(users),
+	)
 	return users, nil
 }
 


### PR DESCRIPTION
## Summary
- slogを使用したデバッグログ機能の追加
- Slack API呼び出しのトレース機能の実装
- 環境変数による柔軟なログレベル制御

## Changes
- `LOG_LEVEL`環境変数でログレベルを制御（DEBUG/INFO/WARN/ERROR）
- `DEBUG=1`でデバッグログを簡単に有効化
- slack_client.goの各メソッドにデバッグログを追加
  - API呼び出し開始時のパラメータログ
  - エラー時のログ
  - 成功時の結果サマリーログ

## Usage
```bash
# デバッグログを有効にして実行
DEBUG=1 ./slack-explorer-mcp

# 詳細なログレベル制御
LOG_LEVEL=DEBUG ./slack-explorer-mcp

# デフォルト（INFOレベル）
./slack-explorer-mcp
```

## Test Plan
- [ ] DEBUG=1でデバッグログが出力されることを確認
- [ ] LOG_LEVELでログレベルが制御できることを確認
- [ ] 機密情報がログに含まれていないことを確認

## Notes
Draft PRとして作成。参考実装として残しておきます。