### PR TITLE
Add session-based caching for streamable HTTP support

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,6 +9,12 @@ import (
 // slackUserTokenKey is the context key for Slack user token
 type slackUserTokenKey struct{}
 
+// sessionIDKey is the context key for session ID
+type sessionIDKey struct{}
+
+// SessionID represents a unique session identifier
+type SessionID string
+
 // SlackUserTokenFromContext retrieves Slack user token from context
 func SlackUserTokenFromContext(ctx context.Context) (string, error) {
 	token, ok := ctx.Value(slackUserTokenKey{}).(string)
@@ -30,4 +36,17 @@ func WithSlackTokenFromEnv(ctx context.Context) context.Context {
 
 func withSlackUserToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, slackUserTokenKey{}, token)
+}
+
+// WithSessionID adds session ID to context
+func WithSessionID(ctx context.Context, sessionID SessionID) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+// SessionIDFromContext retrieves session ID from context
+func SessionIDFromContext(ctx context.Context) SessionID {
+	if sessionID, ok := ctx.Value(sessionIDKey{}).(SessionID); ok {
+		return sessionID
+	}
+	return "default"
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -153,7 +154,16 @@ func main() {
 		handler.SearchUsersByName,
 	)
 
-	if err := server.ServeStdio(s, server.WithStdioContextFunc(WithSlackTokenFromEnv)); err != nil {
+	if err := server.ServeStdio(s, server.WithStdioContextFunc(func(ctx context.Context) context.Context {
+		ctx = WithSlackTokenFromEnv(ctx)
+
+		// Add session ID from ClientSession
+		if session := server.ClientSessionFromContext(ctx); session != nil {
+			ctx = WithSessionID(ctx, SessionID(session.SessionID()))
+		}
+
+		return ctx
+	})); err != nil {
 		fmt.Printf("Server error: %v\n", err)
 		log.Fatalf("Failed to serve: %v", err)
 	}

--- a/user_repository_test.go
+++ b/user_repository_test.go
@@ -119,6 +119,75 @@ func TestUserRepository_FindByDisplayName(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
+	t.Run("uses cache with different session ID", func(t *testing.T) {
+		mockClient := &SlackClientMock{}
+		users1 := []slack.User{
+			{
+				ID: "U1111111",
+				Profile: slack.UserProfile{
+					DisplayName: "session1user",
+					RealName:    "Session 1 User",
+					Email:       "session1@example.com",
+				},
+			},
+		}
+		users2 := []slack.User{
+			{
+				ID: "U2222222",
+				Profile: slack.UserProfile{
+					DisplayName: "session2user",
+					RealName:    "Session 2 User",
+					Email:       "session2@example.com",
+				},
+			},
+		}
+
+		repo := NewUserRepository()
+
+		// Create contexts with different session IDs
+		ctx1 := WithSessionID(t.Context(), SessionID("session-1"))
+		ctx2 := WithSessionID(t.Context(), SessionID("session-2"))
+
+		// Mock API calls for each session
+		mockClient.On("GetUsers", ctx1, []slack.GetUsersOption(nil)).Return(users1, nil).Once()
+		mockClient.On("GetUsers", ctx2, []slack.GetUsersOption(nil)).Return(users2, nil).Once()
+
+		// First call with session 1
+		result1, err1 := repo.FindByDisplayName(ctx1, mockClient, "session1user", true)
+		assert.NoError(t, err1)
+		assert.Len(t, result1, 1)
+		assert.Equal(t, "U1111111", result1[0].ID)
+
+		// First call with session 2 - should call API because different session
+		result2, err2 := repo.FindByDisplayName(ctx2, mockClient, "session2user", true)
+		assert.NoError(t, err2)
+		assert.Len(t, result2, 1)
+		assert.Equal(t, "U2222222", result2[0].ID)
+
+		// sessionCaches structure should be expected
+		assert.Equal(t, map[SessionID]*SessionCache{
+			"session-1": {
+				users: users1,
+			},
+			"session-2": {
+				users: users2,
+			},
+		}, repo.sessionCaches)
+
+		// Second call with session 1 - should use cache
+		result3, err3 := repo.FindByDisplayName(ctx1, mockClient, "session1user", true)
+		assert.NoError(t, err3)
+		assert.Len(t, result3, 1)
+		assert.Equal(t, "U1111111", result3[0].ID)
+
+		// Verify that session 1 context doesn't return session 2 data
+		result4, err4 := repo.FindByDisplayName(ctx1, mockClient, "session2user", true)
+		assert.NoError(t, err4)
+		assert.Len(t, result4, 0) // Should not find session2user in session1 cache
+
+		mockClient.AssertExpectations(t)
+	})
+
 	t.Run("returns empty array when no matches found", func(t *testing.T) {
 		mockClient := &SlackClientMock{}
 		users := []slack.User{


### PR DESCRIPTION
## Why?
This change prepares for streamable HTTP support where multiple sessions might be active simultaneously. Previously, all sessions shared a single cache in UserRepository, which could cause data mixing when multiple users access the system concurrently. With session-based caching, each session maintains its own isolated cache, preventing data leakage between different user sessions.

## What changed?
### Context Management
- Add `SessionID` type and related functions (`WithSessionID`, `SessionIDFromContext`)
- Modify main.go to extract SessionID from `ClientSession` and add it to context during initialization

### UserRepository Improvements  
- Add `SessionCache` struct to hold cached users for specific sessions
- Replace single cache with `map[SessionID]*SessionCache` for session-based caching
- Add `sync.RWMutex` for thread-safe concurrent access
- Implement `searchInUsers` helper function to separate search logic

### Testing
- Add comprehensive test for session isolation that verifies different sessions maintain separate caches
- Ensure no data leakage between sessions

## Testing
- All existing tests continue to pass
- New session isolation test verifies:
  - Different sessions get different cached data
  - Session caches don't interfere with each other  
  - API calls are made only once per session (caching works correctly)
  - No data leakage between sessions
- Manual testing confirmed thread-safe operation with concurrent access