### PR TITLE
Add structured logging with slog for better debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -12,6 +12,14 @@ import (
 const Version = "0.5.0"
 
 func main() {
+	// Setup logging based on DEBUG environment variable
+	if os.Getenv("DEBUG") == "1" {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
+		slog.Debug("Debug logging enabled")
+	}
+
 	// Initialize handler
 	handler := NewHandler()
 	defer handler.Close()
@@ -165,7 +173,7 @@ func main() {
 
 		return ctx
 	})); err != nil {
-		fmt.Printf("Server error: %v\n", err)
-		log.Fatalf("Failed to serve: %v", err)
+		slog.Error("Failed to serve", "error", err)
+		os.Exit(1)
 	}
 }

--- a/user_repository.go
+++ b/user_repository.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -61,8 +62,11 @@ func (r *UserRepository) FindByDisplayName(
 	r.mu.RUnlock()
 
 	if exists && !r.isExpired(cache) {
+		slog.Debug("using cached users", "sessionID", sessionID, "cachedAt", cache.cachedAt)
 		return r.searchInUsers(cache.users, displayName, exact), nil
 	}
+
+	slog.Debug("fetching users", "sessionID", sessionID)
 
 	users, err := client.GetUsers(ctx)
 	if err != nil {


### PR DESCRIPTION
## Why?
The current Slack Explorer MCP server has limited logging capabilities, making it difficult to debug issues and track operations. Particularly for cache operations and user fetching processes, it was hard to understand what was happening internally. Introducing structured logging will improve debugging efficiency and make operational troubleshooting easier.

## What changed?
- `main.go`: Migrated from standard logging to `log/slog` package
- Added structured logging configuration based on DEBUG environment variable
- Unified error handling to use `slog.Error`
- `user_repository.go`: Added debug logging to UserRepository cache operations
  - Logging when using cached data (records sessionID and cachedAt)
  - Logging when fetching users (records sessionID)

## Testing
- Verified that debug logs are properly output when starting the server with DEBUG=1 environment variable
- Confirmed that structured logs are output during UserRepository cache operations
- Verified that existing functionality remains unaffected