### PR TITLE
Reorganize README.md structure to match README_ja.md layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,6 @@ A Model Context Protocol (MCP) server specialized in **retrieving information** 
 
 ## Usage
 
-### Using as Streamable HTTP Server
-
-By default, the server uses stdio for MCP communication. You can start it as a Streamable HTTP server by setting the `TRANSPORT=http` environment variable. In HTTP mode, pass the Slack token using the `X-Slack-User-Token` header.
-
-Starting the server:
-```bash
-# Start HTTP server (default: all interfaces 0.0.0.0, port 8080)
-TRANSPORT=http ./slack-explorer-mcp
-
-# Start with custom host and port
-TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=9090 ./slack-explorer-mcp
-```
-
 ### Common Search Patterns
 
 - **Search in a specific channel**
@@ -129,3 +116,16 @@ TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=9090 ./slack-explorer-mcp
   ```
   Search for messages with file attachments
   ```
+
+### Using as Streamable HTTP Server
+
+By default, the server uses stdio for MCP communication. You can start it as a Streamable HTTP server by setting the `TRANSPORT=http` environment variable. In HTTP mode, pass the Slack token using the `X-Slack-User-Token` header.
+
+Starting the server:
+```bash
+# Start HTTP server (default: all interfaces 0.0.0.0, port 8080)
+TRANSPORT=http ./slack-explorer-mcp
+
+# Start with custom host and port
+TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=9090 ./slack-explorer-mcp
+```


### PR DESCRIPTION
## Why?
README.md and README_ja.md had inconsistent section ordering, which made it difficult for users to find equivalent information between the English and Japanese documentation. The "Using as Streamable HTTP Server" section appeared before "Common Search Patterns" in README.md while the reverse was true in README_ja.md.

Maintaining consistent documentation structure between languages improves user experience and makes documentation maintenance easier.

## What changed?
- Moved "Using as Streamable HTTP Server" section to appear after "Common Search Patterns" in README.md
- Section content remains unchanged - only the order was adjusted
- Now both README.md and README_ja.md follow the same structure:
  1. Common Search Patterns (first)
  2. Using as Streamable HTTP Server (second)

## Testing
- Verified that all section content remains identical
- Confirmed that both documentation files now have matching section order
- No functional changes to the application itself