### PR TITLE
Update HTTP server startup documentation to use Docker commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,16 @@ By default, the server uses stdio for MCP communication. You can start it as a S
 Starting the server:
 ```bash
 # Start HTTP server (default: all interfaces 0.0.0.0, port 8080)
-TRANSPORT=http ./slack-explorer-mcp
+docker run -i --rm --pull always \
+  -e TRANSPORT=http \
+  -p 8080:8080 \
+  ghcr.io/shibayu36/slack-explorer-mcp:latest
 
 # Start with custom host and port
-TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=9090 ./slack-explorer-mcp
+docker run -i --rm --pull always \
+  -e TRANSPORT=http \
+  -e HTTP_HOST=127.0.0.1 \
+  -e HTTP_PORT=9090 \
+  -p 9090:9090 \
+  ghcr.io/shibayu36/slack-explorer-mcp:latest
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -124,8 +124,16 @@ Slackのメッセージやスレッドなどの**情報の取得**に特化し�
 起動方法:
 ```bash
 # HTTPサーバーとして起動（デフォルト: 全インターフェース0.0.0.0、ポート8080）
-TRANSPORT=http ./slack-explorer-mcp
+docker run -i --rm --pull always \
+  -e TRANSPORT=http \
+  -p 8080:8080 \
+  ghcr.io/shibayu36/slack-explorer-mcp:latest
 
 # カスタムホストとポートで起動
-TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=9090 ./slack-explorer-mcp
+docker run -i --rm --pull always \
+  -e TRANSPORT=http \
+  -e HTTP_HOST=127.0.0.1 \
+  -e HTTP_PORT=9090 \
+  -p 9090:9090 \
+  ghcr.io/shibayu36/slack-explorer-mcp:latest
 ```


### PR DESCRIPTION
## Why?
The current documentation for starting the server as a Streamable HTTP server uses direct binary execution commands (./slack-explorer-mcp), which is inconsistent with the main MCP server setup that uses Docker commands. Since the project is distributed as a Docker image and the main setup instructions use Docker commands, users would expect the HTTP server startup instructions to follow the same pattern for consistency.

Having consistent Docker-based instructions across all deployment modes improves user experience and reduces confusion when setting up the server in different environments.

## What changed?
- Updated README_ja.md and README.md HTTP server startup examples to use Docker commands
- Replaced `./slack-explorer-mcp` with `docker run` commands
- Added port mapping (-p) options for proper Docker networking

## Testing
- Verified Docker HTTP server startup works with default and custom port configurations
- Confirmed proper server logging output in both scenarios