### PR TITLE
Add default value for exact parameter in search_users_by_name tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func main() {
 			),
 			mcp.WithBoolean("exact",
 				mcp.Description("If true (default), performs exact match. If false, performs partial match"),
+				mcp.DefaultBool(true),
 			),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithReadOnlyHintAnnotation(true),


### PR DESCRIPTION
## Why?
The `exact` parameter in the `search_users_by_name` MCP tool currently lacks a default value, which can lead to ambiguity about the expected behavior when the parameter is not explicitly specified. Adding a default value of `true` makes the tool's behavior more predictable and aligns with the typical expectation that name searches should be exact matches by default.

This improvement enhances the MCP tool schema definition and provides clearer API documentation for clients using this tool.

## What changed?
- Added `mcp.DefaultBool(true)` to the `exact` parameter in `main.go`

## Testing
- Confirmed using https://github.com/modelcontextprotocol/inspector