### PR TITLE
Add docs/onetime/ caveat to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,5 +115,10 @@ func (r *UserRepository) FindByDisplayName(
 - Always update README_ja.md first when adding or updating documentation
 - Then update README.md with English translation using simple, clear English that non-native speakers can easily understand
 
+### Handling `docs/onetime/`
+- Documents under `docs/onetime/` (requirements, design memos, etc.) are point-in-time snapshots. They may be referenced for context, but often contain outdated or incorrect content.
+- Do not treat their content as ground truth. Always verify the current state against the actual code or `git log`.
+- For "current facts" such as implementation status, file layout, or API signatures, treat the source code as the primary reference, not `docs/onetime/`.
+
 ## Creating Pull Request
 Use `.github/pull_request_template.md` to create pull request.


### PR DESCRIPTION
## Why?

Documents under `docs/onetime/` are point-in-time snapshots (requirements, design memos, etc.), and Claude Code has been observed treating their content as ground truth even when it conflicts with the current implementation. Make it explicit that these should not be trusted blindly, and that the source code (and `git log`) is the primary reference for current facts.

## What changed?

- Added a `Handling docs/onetime/` subsection under Documentation Guidelines in CLAUDE.md, instructing that these documents are point-in-time snapshots and source code should be treated as the primary reference for current facts.

## Testing

- Reviewed the added guidance for clarity.